### PR TITLE
Improvements for Kitty protocol supported terminals and different default shell.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ options:
 - [fzf](https://github.com/junegunn/fzf) 0.56.0+
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp)
 - [mpv](https://mpv.io/)
-- One of the following for thumbnails:
+- One of the following for thumbnails,in fallback order:
   - [ueberzugpp](https://github.com/jstkdng/ueberzugpp) (recommended, esp. on
     X11)
   - [kitty](https://github.com/kovidgoyal/kitty) (works within `kitty` and

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ options:
 - [fzf](https://github.com/junegunn/fzf) 0.56.0+
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp)
 - [mpv](https://mpv.io/)
-- One of the following for thumbnails,in fallback order:
+- One of the following for thumbnails, in fallback order:
   - [ueberzugpp](https://github.com/jstkdng/ueberzugpp) (recommended, esp. on
     X11)
   - [kitty](https://github.com/kovidgoyal/kitty) (works within `kitty` and

--- a/src/scrapetubefzf/__main__.py
+++ b/src/scrapetubefzf/__main__.py
@@ -191,7 +191,7 @@ def run_fzf(n: int) -> subprocess.CompletedProcess:
             '--bind', 'resize:refresh-preview',
             '--bind', f'left:reload({my_tail} "{VIDEOS_FILE}")+change-header(Tab: multi-select | Enter: play | Alt-d: download | →: channels)',
             '--bind', f'right:reload({my_tail} "{CHANNELS_FILE}")+change-header(Tab: multi-select | Enter: play | Alt-d: download | ←: videos)',
-            '--bind', f'alt-d:execute(bash -c "{CLEAR_SCRIPT} && {DOWNLOAD_SCRIPT} {{+}}")+abort'],
+            '--bind', f'alt-d:execute({CLEAR_SCRIPT} && {DOWNLOAD_SCRIPT} {{+}})+abort'],
         text=True,
         capture_output=True,
         env=fzf_env

--- a/src/scrapetubefzf/__main__.py
+++ b/src/scrapetubefzf/__main__.py
@@ -180,28 +180,29 @@ def run_fzf(n: int) -> subprocess.CompletedProcess:
         'MAIN_PID': str(os.getpid())
     })
 
+    # FIX: We wrap the commands that use '&&' inside 'bash -c' 
+    # This ensures that even if Other Shell is your default shell(I'm using Nushell), 
     fzf_result = subprocess.run(
         ['fzf', '--multi', '--reverse',
             '--read0', '--gap', '--ansi',
             '--delimiter', '\t', '--with-nth=2',  # Skip ID in display
             '--prompt=Select: ', '--info=hidden',
             '--header=Tab: multi-select | Enter: play | Alt-d: download | →: channels',
-            '--preview', f'{CLEAR_SCRIPT} && {PREVIEW_SCRIPT} {{}}',
+            '--preview', f'bash -c "{CLEAR_SCRIPT} && {PREVIEW_SCRIPT} {{}}" ',
             '--bind', 'resize:refresh-preview',
             '--bind', f'left:reload({my_tail} "{VIDEOS_FILE}")+change-header(Tab: multi-select | Enter: play | Alt-d: download | →: channels)',
             '--bind', f'right:reload({my_tail} "{CHANNELS_FILE}")+change-header(Tab: multi-select | Enter: play | Alt-d: download | ←: videos)',
-            '--bind', f'alt-d:execute({CLEAR_SCRIPT} && {DOWNLOAD_SCRIPT} {{+}})+abort'],
+            '--bind', f'alt-d:execute(bash -c "{CLEAR_SCRIPT} && {DOWNLOAD_SCRIPT} {{+}}")+abort'],
         text=True,
         capture_output=True,
         env=fzf_env
     )
 
     if ueberzug_fifo:
-        subprocess.run([CLEAR_SCRIPT], env=fzf_env)
+        subprocess.run([f'bash -c "{CLEAR_SCRIPT}"'], shell=True, env=fzf_env) # Added bash wrapper here too
         cleanup_ueberzug(ueberzug_fifo)
 
     return fzf_result
-
 
 def main():
     """Main function of scrapetubefzf."""

--- a/src/scrapetubefzf/__main__.py
+++ b/src/scrapetubefzf/__main__.py
@@ -203,6 +203,7 @@ def run_fzf(n: int) -> subprocess.CompletedProcess:
 
     return fzf_result
 
+
 def main():
     """Main function of scrapetubefzf."""
     # Parse arguments

--- a/src/scrapetubefzf/__main__.py
+++ b/src/scrapetubefzf/__main__.py
@@ -198,7 +198,7 @@ def run_fzf(n: int) -> subprocess.CompletedProcess:
     )
 
     if ueberzug_fifo:
-        subprocess.run([f'bash -c "{CLEAR_SCRIPT}"'], shell=True, env=fzf_env) # Added bash wrapper here too
+        subprocess.run([CLEAR_SCRIPT], env=fzf_env)
         cleanup_ueberzug(ueberzug_fifo)
 
     return fzf_result

--- a/src/scrapetubefzf/__main__.py
+++ b/src/scrapetubefzf/__main__.py
@@ -180,8 +180,6 @@ def run_fzf(n: int) -> subprocess.CompletedProcess:
         'MAIN_PID': str(os.getpid())
     })
 
-    # FIX: We wrap the commands that use '&&' inside 'bash -c' 
-    # This ensures that even if Other Shell is your default shell(I'm using Nushell), 
     fzf_result = subprocess.run(
         ['fzf', '--multi', '--reverse',
             '--read0', '--gap', '--ansi',

--- a/src/scrapetubefzf/scripts/preview.sh
+++ b/src/scrapetubefzf/scripts/preview.sh
@@ -38,11 +38,6 @@ fi
 if [ -f "$THUMB_PATH" ]; then
     if [ -p "$UEBERZUG_FIFO" ]; then
         echo '{"action": "add", "identifier": "fzf", "x": '$FZF_PREVIEW_LEFT', "y": '$FZF_PREVIEW_TOP', "max_width": '$FZF_PREVIEW_COLUMNS', "max_height": '$FZF_PREVIEW_LINES', "path": "'$THUMB_PATH'"}' >> "$UEBERZUG_FIFO"
-	elif command -v imgcat >/dev/null 2>&1 && \
-         { [[ "$TERM_PROGRAM" =~ ^(WezTerm|iTerm.app)$ ]] || \
-           [[ -n "$WEZTERM_PANE" ]] || \
-           [[ -n "$ITERM_SESSION_ID" ]]; }; then
-        imgcat --width "$FZF_PREVIEW_COLUMNS" --height "$FZF_PREVIEW_LINES" "$THUMB_PATH"
     elif command -v kitten >/dev/null 2>&1 && \
          { [[ -n "$KITTY_WINDOW_ID" ]] || \
            [[ -n "$GHOSTTY_BIN_DIR" ]] || \ # Robust

--- a/src/scrapetubefzf/scripts/preview.sh
+++ b/src/scrapetubefzf/scripts/preview.sh
@@ -39,10 +39,7 @@ if [ -f "$THUMB_PATH" ]; then
     if [ -p "$UEBERZUG_FIFO" ]; then
         echo '{"action": "add", "identifier": "fzf", "x": '$FZF_PREVIEW_LEFT', "y": '$FZF_PREVIEW_TOP', "max_width": '$FZF_PREVIEW_COLUMNS', "max_height": '$FZF_PREVIEW_LINES', "path": "'$THUMB_PATH'"}' >> "$UEBERZUG_FIFO"
     elif command -v kitten >/dev/null 2>&1 && \
-         { [[ -n "$KITTY_WINDOW_ID" ]] || \
-           [[ -n "$GHOSTTY_BIN_DIR" ]] || \
-           [[ "$TERM" == *ghostty* ]] || \
-           [[ "$TERM" == *kitty* ]]; }; then
+         { [[ -n "$KITTY_WINDOW_ID" ]] || [[ "$TERM_PROGRAM" == "ghostty" ]]; }; then
         kitten icat --clear --stdin=no --transfer-mode=memory \
             --unicode-placeholder --scale-up \
             --place="$((FZF_PREVIEW_COLUMNS))x$((FZF_PREVIEW_LINES))@0x0" \

--- a/src/scrapetubefzf/scripts/preview.sh
+++ b/src/scrapetubefzf/scripts/preview.sh
@@ -40,8 +40,8 @@ if [ -f "$THUMB_PATH" ]; then
         echo '{"action": "add", "identifier": "fzf", "x": '$FZF_PREVIEW_LEFT', "y": '$FZF_PREVIEW_TOP', "max_width": '$FZF_PREVIEW_COLUMNS', "max_height": '$FZF_PREVIEW_LINES', "path": "'$THUMB_PATH'"}' >> "$UEBERZUG_FIFO"
     elif command -v kitten >/dev/null 2>&1 && \
          { [[ -n "$KITTY_WINDOW_ID" ]] || \
-           [[ -n "$GHOSTTY_BIN_DIR" ]] || \ # Robust
-           [[ "$TERM" == *ghostty* ]] || \ # if xterm-* used
+           [[ -n "$GHOSTTY_BIN_DIR" ]] || \
+           [[ "$TERM" == *ghostty* ]] || \
            [[ "$TERM" == *kitty* ]]; }; then
         kitten icat --clear --stdin=no --transfer-mode=memory \
             --unicode-placeholder --scale-up \

--- a/src/scrapetubefzf/scripts/preview.sh
+++ b/src/scrapetubefzf/scripts/preview.sh
@@ -38,17 +38,18 @@ fi
 if [ -f "$THUMB_PATH" ]; then
     if [ -p "$UEBERZUG_FIFO" ]; then
         echo '{"action": "add", "identifier": "fzf", "x": '$FZF_PREVIEW_LEFT', "y": '$FZF_PREVIEW_TOP', "max_width": '$FZF_PREVIEW_COLUMNS', "max_height": '$FZF_PREVIEW_LINES', "path": "'$THUMB_PATH'"}' >> "$UEBERZUG_FIFO"
-    elif [ -n "$KITTY_WINDOW_ID" ]; then
-        kitty icat --clear --stdin=no --transfer-mode=memory \
-        --unicode-placeholder --scale-up \
-        --place="$((FZF_PREVIEW_COLUMNS))x$((FZF_PREVIEW_LINES))@0x0" \
-        "$THUMB_PATH"
+	elif command -v kitten >/dev/null 2>&1 || command -v kitty >/dev/null 2>&1; then # Kitty Supported Terminal, needs kitten installed
+		CMD=$(command -v kitten || command -v kitty)
+		$CMD icat --clear --stdin=no --transfer-mode=memory \
+		--unicode-placeholder --scale-up \
+		--place="$((FZF_PREVIEW_COLUMNS))x$((FZF_PREVIEW_LINES))@0x0" \
+		"$THUMB_PATH"
     elif command -v chafa >/dev/null 2>&1; then
         chafa -s "$((FZF_PREVIEW_COLUMNS))x$((FZF_PREVIEW_LINES))" "$THUMB_PATH"
     elif command -v catimg >/dev/null 2>&1; then
         catimg -w "$((2 * FZF_PREVIEW_COLUMNS))" "$THUMB_PATH"
     else
         echo "Thumbnail available at: $THUMB_PATH"
-        echo "Install ueberzug, chafa, or catimg to view thumbnails in terminal"
+        echo "Install ueberzug, chafa, or catimg to view thumbnails in terminal for kitty protocol supported terminal install kitten"
     fi
 fi


### PR DESCRIPTION
### Cross-Shell Compatibility
fzf previews failed in non-POSIX shells (like Nushell) because they inherited the user's $SHELL syntax.
Wrapped internal logic in `bash -c` to ensure operators like `&&` are always interpreted correctly.

### Expanded Terminal Image Support
Image previews were restricted to the Kitty terminal via `$KITTY_WINDOW_ID` checks, excluding Ghostty and WezTerm.
Shifted detection to check for kitten/kitty binaries rather than environment variables.
